### PR TITLE
POM, using jena-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>jena-geosparql</artifactId>
+  <packaging>jar</packaging>
+  <name>Apache Jena - GeoSPARQL Engine</name>
+  <version>3.12.0-SNAPSHOT</version>
+
+  <parent>
+    <groupId>org.apache.jena</groupId>
+    <artifactId>jena</artifactId>
+    <version>3.12.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <description>GeoSPARQL implementation for Apache Jena</description>
+
+  <properties>
+    <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
+    <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
+    <automatic.module.name>org.apache.jena.jena-geosparql</automatic.module.name>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-arq</artifactId>
+      <version>3.12.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.sis.core</groupId>
+      <artifactId>sis-referencing</artifactId>
+      <version>0.8</version>
+    </dependency>
+
+     <dependency>
+       <groupId>org.locationtech.jts</groupId>
+       <artifactId>jts-core</artifactId>
+       <version>1.16.1</version>
+     </dependency>
+
+     <dependency>
+       <groupId>org.jdom</groupId>
+       <artifactId>jdom2</artifactId>
+       <version>2.0.6</version>
+     </dependency>
+
+     <dependency>
+       <groupId>io.github.galbiston</groupId>
+       <artifactId>expiring-map</artifactId>
+       <version>1.0.2</version>
+     </dependency>
+
+     <dependency>
+       <groupId>org.apache.commons</groupId>
+       <artifactId>commons-collections4</artifactId>
+     </dependency>
+
+  </dependencies>
+
+  <build>
+
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <!--
+          The test collections TC_General, TC_Riot, TC_Atlas
+          are development support that collect the relevant
+          tests for partial testing during development.
+        -->
+            <include>**/TS_*.java</include>
+            <include>**/TC_Scripted.java</include>
+            <include>**/TC_DAWG.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <!-- <phase>package</phase> package is the default -->
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>attach-sources-test</id>
+            <goals>
+              <goal>test-jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <version>true</version>
+          <show>public</show>
+          <quiet>true</quiet>
+          <encoding>UTF-8</encoding>
+          <windowtitle>Apache Jena GeoSPARQL</windowtitle>
+          <doctitle>Apache Jena GeoSPARQL ${project.version}</doctitle>
+          <bottom>Licenced under the Apache License, Version 2.0</bottom>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
A pom.xml for geosparql-jena that uses the Apache Jena parent settings.

To run 

`mvn clean install -Drat.skip=true`

The "rat.check" step has to be skipped because it finds gradle related files and some data files. These are easier to sort out when the code is in-place.