### PR TITLE
Clean up compile time Eclipse warnings

### DIFF
--- a/src/main/java/io/github/galbiston/geosparql_jena/implementation/UnitsOfMeasure.java
+++ b/src/main/java/io/github/galbiston/geosparql_jena/implementation/UnitsOfMeasure.java
@@ -38,7 +38,7 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
  */
 public class UnitsOfMeasure implements Serializable {
 
-    private final Unit unit;
+    private final Unit<Length> unit;
     private final String unitURI;
     private final boolean isLinearUnits;
 
@@ -49,19 +49,21 @@ public class UnitsOfMeasure implements Serializable {
     public static final double EQUATORIAL_DEGREE_TO_METRES = 111319.8922;
     public static final double EARTH_MEAN_RADIUS = 6371008.7714; //Earth Mean Radius
 
+    @SuppressWarnings("unchecked")
     public UnitsOfMeasure(CoordinateReferenceSystem crs) {
-        this.unit = crs.getCoordinateSystem().getAxis(0).getUnit();
+        this.unit = (Unit<Length>)crs.getCoordinateSystem().getAxis(0).getUnit();
         this.unitURI = UnitsRegistry.getUnitURI(unit);
         this.isLinearUnits = UnitsRegistry.isLinearUnits(unitURI);
     }
 
+    @SuppressWarnings("unchecked")
     public UnitsOfMeasure(String unitURI) {
-        this.unit = UnitsRegistry.getUnit(unitURI);
+        this.unit = (Unit<Length>)UnitsRegistry.getUnit(unitURI);
         this.unitURI = UnitsRegistry.getUnitURI(unit);
         this.isLinearUnits = UnitsRegistry.isLinearUnits(unitURI);
     }
 
-    public Unit getUnit() {
+    public Unit<Length> getUnit() {
         return unit;
     }
 
@@ -82,9 +84,7 @@ public class UnitsOfMeasure implements Serializable {
      * @return Distance after conversion.
      * @throws UnitsConversionException
      */
-    @SuppressWarnings("unchecked")
     public static final Double conversion(double sourceDistance, String sourceDistanceUnitsURI, String targetDistanceUnitsURI) throws UnitsConversionException {
-
         return conversion(sourceDistance, new UnitsOfMeasure(sourceDistanceUnitsURI), new UnitsOfMeasure(targetDistanceUnitsURI));
     }
 
@@ -97,7 +97,6 @@ public class UnitsOfMeasure implements Serializable {
      * @return Distance after conversion.
      * @throws UnitsConversionException
      */
-    @SuppressWarnings("unchecked")
     public static final Double conversion(double sourceDistance, UnitsOfMeasure sourceUnits, UnitsOfMeasure targetUnits) throws UnitsConversionException {
 
         Boolean isSourceUnitsLinear = sourceUnits.isLinearUnits();
@@ -113,8 +112,8 @@ public class UnitsOfMeasure implements Serializable {
         }
 
         //Find which type of measure for the distance is being used.
-        Unit sourceUnit = sourceUnits.getUnit();
-        Unit targetUnit = targetUnits.getUnit();
+        Unit<Length> sourceUnit = sourceUnits.getUnit();
+        Unit<Length> targetUnit = targetUnits.getUnit();
 
         Quantity<Length> distance = Quantities.create(sourceDistance, sourceUnit);
         Quantity<Length> targetDistance = distance.to(targetUnit);

--- a/src/main/java/io/github/galbiston/geosparql_jena/implementation/great_circle/GreatCirclePointDistance.java
+++ b/src/main/java/io/github/galbiston/geosparql_jena/implementation/great_circle/GreatCirclePointDistance.java
@@ -137,7 +137,7 @@ public class GreatCirclePointDistance {
     }
 
     /**
-     * Normalise Longitude in degrees to -180 -> 180 range.
+     * Normalise Longitude in degrees to the range -180 to 180.
      *
      * @param lonDegrees
      * @return Lat/Lon Point in degrees.

--- a/src/main/java/io/github/galbiston/geosparql_jena/implementation/jts/CustomCoordinateSequence.java
+++ b/src/main/java/io/github/galbiston/geosparql_jena/implementation/jts/CustomCoordinateSequence.java
@@ -419,7 +419,6 @@ public class CustomCoordinateSequence implements CoordinateSequence, Serializabl
 
     @Override
     @Deprecated
-    @SuppressWarnings("deprecation")
     public CustomCoordinateSequence clone() {
         return new CustomCoordinateSequence(x, y, z, m);
     }

--- a/src/main/java/io/github/galbiston/geosparql_jena/implementation/registry/MathTransformRegistry.java
+++ b/src/main/java/io/github/galbiston/geosparql_jena/implementation/registry/MathTransformRegistry.java
@@ -37,13 +37,12 @@ import org.slf4j.LoggerFactory;
 public class MathTransformRegistry {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-    private static final MultiKeyMap<MultiKey, MathTransform> MATH_TRANSFORM_REGISTRY = MultiKeyMap.multiKeyMap(new HashedMap<>());
+    private static final MultiKeyMap<CoordinateReferenceSystem, MathTransform> MATH_TRANSFORM_REGISTRY = MultiKeyMap.multiKeyMap(new HashedMap<>());
 
-    @SuppressWarnings("unchecked")
     public synchronized static final MathTransform getMathTransform(CoordinateReferenceSystem sourceCRS, CoordinateReferenceSystem targetCRS) throws FactoryException, MismatchedDimensionException, TransformException {
 
         MathTransform transform;
-        MultiKey key = new MultiKey<>(sourceCRS, targetCRS);
+        MultiKey<CoordinateReferenceSystem> key = new MultiKey<>(sourceCRS, targetCRS);
         if (MATH_TRANSFORM_REGISTRY.containsKey(key)) {
             transform = MATH_TRANSFORM_REGISTRY.get(key);
         } else {

--- a/src/main/java/io/github/galbiston/geosparql_jena/implementation/registry/UnitsRegistry.java
+++ b/src/main/java/io/github/galbiston/geosparql_jena/implementation/registry/UnitsRegistry.java
@@ -32,8 +32,8 @@ import org.apache.sis.measure.Units;
  */
 public class UnitsRegistry {
 
-    private static final Map<String, Unit> UNITS_REGISTRY = Collections.synchronizedMap(new HashMap<>());
-    private static final Map<Unit, String> UNITS_URI_REGISTRY = Collections.synchronizedMap(new HashMap<>());
+    private static final Map<String, Unit<?>> UNITS_REGISTRY = Collections.synchronizedMap(new HashMap<>());
+    private static final Map<Unit<?>, String> UNITS_URI_REGISTRY = Collections.synchronizedMap(new HashMap<>());
 
     private static final Unit<Length> YARD = Units.METRE.multiply(1.0936132983);
 
@@ -93,7 +93,7 @@ public class UnitsRegistry {
         //TODO: EPSG also defined units URIs at https://epsg.io/9096-units. More exhaustive than OGC.
     }
 
-    public static final void addUnit(String unitURI, Unit unit) {
+    public static final void addUnit(String unitURI, Unit<?> unit) {
         UNITS_REGISTRY.putIfAbsent(unitURI, unit);
         UNITS_URI_REGISTRY.putIfAbsent(unit, unitURI);
     }
@@ -102,7 +102,7 @@ public class UnitsRegistry {
         addUnit(unitsOfMeasure.getUnitURI(), unitsOfMeasure.getUnit());
     }
 
-    public static final Unit getUnit(String unitURI) {
+    public static final Unit<?> getUnit(String unitURI) {
         return UNITS_REGISTRY.get(unitURI);
     }
 
@@ -110,7 +110,7 @@ public class UnitsRegistry {
         return getUnitURI(unitOfMeasure.getUnit());
     }
 
-    public static final String getUnitURI(Unit unit) {
+    public static final String getUnitURI(Unit<?> unit) {
         return UNITS_URI_REGISTRY.get(unit);
     }
 
@@ -118,8 +118,8 @@ public class UnitsRegistry {
 
         if (UNITS_REGISTRY.containsKey(unitURI)) {
 
-            Unit unit = UNITS_REGISTRY.get(unitURI);
-            Unit unitSI = unit.getSystemUnit();
+            Unit<?> unit = UNITS_REGISTRY.get(unitURI);
+            Unit<?> unitSI = unit.getSystemUnit();
 
             return unitSI.equals(Units.METRE);
         } else {

--- a/src/main/java/io/github/galbiston/geosparql_jena/spatial/property_functions/cardinal/GenericCardinalPropertyFunction.java
+++ b/src/main/java/io/github/galbiston/geosparql_jena/spatial/property_functions/cardinal/GenericCardinalPropertyFunction.java
@@ -19,7 +19,6 @@ import io.github.galbiston.geosparql_jena.implementation.GeometryWrapper;
 import io.github.galbiston.geosparql_jena.implementation.SRSInfo;
 import io.github.galbiston.geosparql_jena.spatial.ConvertLatLon;
 import io.github.galbiston.geosparql_jena.spatial.SearchEnvelope;
-import static io.github.galbiston.geosparql_jena.spatial.property_functions.GenericSpatialPropertyFunction.DEFAULT_LIMIT;
 import io.github.galbiston.geosparql_jena.spatial.property_functions.SpatialArguments;
 import java.util.List;
 import org.apache.jena.datatypes.DatatypeFormatException;

--- a/src/test/java/io/github/galbiston/geosparql_jena/configuration/GeoSPARQLOperationsTest.java
+++ b/src/test/java/io/github/galbiston/geosparql_jena/configuration/GeoSPARQLOperationsTest.java
@@ -153,7 +153,7 @@ public class GeoSPARQLOperationsTest {
         System.out.println("convert");
         Model inputModel = CONVERTED_SRS_DATA;
         GeometryDatatype outputDatatype = GMLDatatype.INSTANCE;
-        TreeSet expResult = extract(CONVERTED_DATATYPE_DATA);
+        TreeSet<String> expResult = extract(CONVERTED_DATATYPE_DATA);
         Model instance = GeoSPARQLOperations.convert(inputModel, outputDatatype);
         TreeSet<String> result = extract(instance);
 

--- a/src/test/java/io/github/galbiston/geosparql_jena/implementation/UnitsOfMeasureTest.java
+++ b/src/test/java/io/github/galbiston/geosparql_jena/implementation/UnitsOfMeasureTest.java
@@ -68,10 +68,6 @@ public class UnitsOfMeasureTest {
         UnitsOfMeasure targetUnitsOfMeasure = new UnitsOfMeasure(crs);
         Double expResult = null;
         Double result = UnitsOfMeasure.conversion(distance, sourceDistanceUnitURI, targetUnitsOfMeasure.getUnitURI());
-
-        //System.out.println("Exp: " + expResult);
-        //System.out.println("Res: " + result);
-        assertEquals(expResult, result, 0.0);
     }
 
     /**
@@ -89,10 +85,6 @@ public class UnitsOfMeasureTest {
         UnitsOfMeasure targetUnitsOfMeasure = new UnitsOfMeasure(crs);
         Double expResult = null;
         Double result = UnitsOfMeasure.conversion(distance, sourceDistanceUnitURI, targetUnitsOfMeasure.getUnitURI());
-
-        //System.out.println("Exp: " + expResult);
-        //System.out.println("Res: " + result);
-        assertEquals(expResult, result, 0.0);
     }
 
     /**
@@ -175,10 +167,6 @@ public class UnitsOfMeasureTest {
 
         Double expResult = null;
         Double result = UnitsOfMeasure.conversion(distance, sourceDistanceUnitURI, targetUnitsOfMeasure.getUnitURI());
-
-        //System.out.println("Exp: " + expResult);
-        //System.out.println("Res: " + result);
-        assertEquals(expResult, result, 0.0);
     }
 
     /**

--- a/src/test/java/io/github/galbiston/geosparql_jena/implementation/great_circle/GreatCirclePointDistanceTest.java
+++ b/src/test/java/io/github/galbiston/geosparql_jena/implementation/great_circle/GreatCirclePointDistanceTest.java
@@ -26,10 +26,7 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.locationtech.jts.geom.GeometryFactory;
 
-/**
- *
- *
- */
+
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class GreatCirclePointDistanceTest {
 


### PR DESCRIPTION
Clean up warnings seen in Eclipse.

UnitsOfMearureTest has null boxed value (not that the test gets to that point - an earlier step throws an exception).

Used  `Unit<Length>` in `UnitsOfMeasure` which seems to be the generic type.  If not, either `Unit<?>` or revert to raw `Unit`.
